### PR TITLE
Implement database connection factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,20 @@ The system follows a 3-tier architecture:
     ```sh
     pre-commit install
     ```
-4.  Set up environment variables for the MongoDB connection (e.g., in a `.env` file).
+4.  Configure the MongoDB connection using environment variables. Define the following values (e.g., in a `.env` file):
+    - `DB_USER` and `DB_PASSWORD` – credentials for the database.
+    - `DB_HOST` – MongoDB host (defaults to `localhost` if omitted).
+    - `DB_NAME` – name of the database.
+    - `DB_CONNECTION` – optional full connection string containing the username, password, and host. If provided, this overrides the individual settings.
 5.  Run the application:
     ```sh
     uvicorn app.main:app --reload
+    ```
+6.  Register the Beanie initialization handler in your FastAPI app:
+    ```python
+    from app.db import create_init_beanie
+
+    app.add_event_handler("startup", create_init_beanie([]))
     ```
 
 ## Testing

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,29 @@
+import os
+from typing import Iterable
+
+from motor.motor_asyncio import AsyncIOMotorClient
+from beanie import init_beanie
+
+
+def get_connection_string() -> str:
+    """Build the MongoDB connection string from environment variables."""
+    connection = os.getenv("DB_CONNECTION")
+    if connection:
+        return connection
+
+    user = os.getenv("DB_USER")
+    password = os.getenv("DB_PASSWORD")
+    host = os.getenv("DB_HOST", "localhost")
+    return f"mongodb://{user}:{password}@{host}"
+
+
+def create_init_beanie(models: Iterable[type]):
+    """Return a startup handler that initializes Beanie."""
+
+    async def init() -> None:
+        connection = get_connection_string()
+        db_name = os.getenv("DB_NAME")
+        client = AsyncIOMotorClient(connection)
+        await init_beanie(database=client[db_name], document_models=list(models))
+
+    return init

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,14 @@
+from app.db import get_connection_string
+
+
+def test_get_connection_string_uses_full_connection(monkeypatch):
+    monkeypatch.setenv("DB_CONNECTION", "mongodb://user:pass@host")
+    assert get_connection_string() == "mongodb://user:pass@host"
+
+
+def test_get_connection_string_builds_from_parts(monkeypatch):
+    monkeypatch.delenv("DB_CONNECTION", raising=False)
+    monkeypatch.setenv("DB_USER", "u")
+    monkeypatch.setenv("DB_PASSWORD", "p")
+    monkeypatch.setenv("DB_HOST", "db")
+    assert get_connection_string() == "mongodb://u:p@db"


### PR DESCRIPTION
## Summary
- create `create_init_beanie` factory for startup database initialization
- configure connection string via DB_* environment variables
- document env variables and usage in README
- test connection string helper

## Testing
- `ruff check .`
- `black . --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_687a182808ec8326ae55def56b9d9a74