### PR TITLE
Implement Mongo-based auth and update tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DB_USER=runbook
+DB_PASSWORD=secret
+DB_HOST=localhost
+DB_NAME=runbook
+DB_CONNECTION=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The system follows a 3-tier architecture:
     ```sh
     pre-commit install
     ```
-4.  Configure the MongoDB connection using environment variables. Define the following values (e.g., in a `.env` file):
+4.  Copy `.env.example` to `.env` and configure the connection settings. The file defines the following values:
     - `DB_USER` and `DB_PASSWORD` – credentials for the database.
     - `DB_HOST` – MongoDB host (defaults to `localhost` if omitted).
     - `DB_NAME` – name of the database.
@@ -77,12 +77,7 @@ The system follows a 3-tier architecture:
     ```sh
     uvicorn app.main:app --reload
     ```
-6.  Register the Beanie initialization handler in your FastAPI app:
-    ```python
-    from app.db import create_init_beanie
-
-    app.add_event_handler("startup", create_init_beanie([]))
-    ```
+6.  The application initializes its MongoDB database on startup.
 
 ## Testing
 
@@ -93,7 +88,7 @@ pytest
 
 ## API Endpoints
 
-Authentication is handled via an `X-API-KEY` header.
+Authentication is handled via an `X-API-KEY` header. Users obtain an API key by signing up and logging in. API keys and user roles are stored in the MongoDB database.
 
 - `GET /runbooks`: List all runbooks.
 - `POST /runbooks`: Create a new runbook.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+# Package

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,33 @@
+from fastapi import Header, HTTPException, status, Depends
+from .models import User
+
+
+async def get_current_role(
+    x_api_key: str | None = Header(None, alias="X-API-KEY")
+) -> str:
+    """Validate API key from database and return associated role."""
+    if x_api_key is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing API key"
+        )
+
+    # Retrieve user with given API key
+    user = await User.find_one({"api_key": x_api_key})
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key"
+        )
+    return user.role
+
+
+def require_roles(*allowed_roles: str):
+    """Dependency enforcing that the current role is in allowed_roles."""
+
+    async def dependency(role: str = Depends(get_current_role)) -> None:
+        if role not in allowed_roles:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Forbidden",
+            )
+
+    return Depends(dependency)

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,22 @@
 from fastapi import FastAPI
 
+from app.auth import require_roles
+from app.users import router as users_router
+from app.db import create_init_beanie
+from app.models import User
+
 app = FastAPI()
+app.add_event_handler("startup", create_init_beanie([User]))
 
 
 @app.get("/")
 def read_root():
     return {"Hello": "World"}
+
+
+@app.get("/protected")
+async def protected(_=require_roles("sre")):
+    return {"protected": True}
+
+
+app.include_router(users_router)

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,11 @@
+from beanie import Document
+from pydantic import Field
+
+
+class User(Document):
+    """User account stored in MongoDB."""
+
+    username: str = Field(index=True)
+    password: str
+    api_key: str
+    role: str

--- a/app/users.py
+++ b/app/users.py
@@ -1,0 +1,49 @@
+import secrets
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from .models import User
+from .auth import get_current_role
+
+router = APIRouter()
+
+
+class SignupRequest(BaseModel):
+    username: str
+    password: str
+    role: str = "developer"
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+@router.post("/signup")
+async def signup(data: SignupRequest):
+    existing = await User.find_one({"username": data.username})
+    if existing:
+        raise HTTPException(status_code=400, detail="Username already exists")
+
+    api_key = secrets.token_hex(16)
+    user = User(
+        username=data.username,
+        password=data.password,
+        api_key=api_key,
+        role=data.role,
+    )
+    await user.insert()
+    return {"api_key": api_key}
+
+
+@router.post("/login")
+async def login(data: LoginRequest):
+    user = await User.find_one({"username": data.username})
+    if not user or user.password != data.password:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    return {"api_key": user.api_key}
+
+
+@router.post("/logout")
+async def logout(role: str = Depends(get_current_role)):
+    return {"detail": "Logged out"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3'
+services:
+  mongo:
+    image: mongo
+    volumes:
+      - mongo-data:/data/db
+    ports:
+      - "27017:27017"
+  app:
+    build: .
+    environment:
+      DB_USER: runbook
+      DB_PASSWORD: secret
+      DB_HOST: mongo
+      DB_NAME: runbook
+    depends_on:
+      - mongo
+    ports:
+      - "8000:8000"
+volumes:
+  mongo-data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,8 +35,6 @@ pytest
 python-dotenv
 PyYAML
 sniffio
-SQLAlchemy
-sqlmodel
 starlette
 typing-inspection
 typing_extensions
@@ -45,3 +43,5 @@ uvloop
 virtualenv
 watchfiles
 websockets
+mongomock
+mongomock_motor

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,60 @@
+# ruff: noqa: E402
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+from fastapi.testclient import TestClient
+from mongomock_motor import AsyncMongoMockClient
+
+import app.db as db
+from app.main import app
+
+
+@pytest.fixture(autouse=True)
+def setup_db(monkeypatch):
+    monkeypatch.setattr(db, "AsyncIOMotorClient", AsyncMongoMockClient)
+    monkeypatch.setenv("DB_USER", "u")
+    monkeypatch.setenv("DB_PASSWORD", "p")
+    monkeypatch.setenv("DB_HOST", "localhost")
+    monkeypatch.setenv("DB_NAME", "testdb")
+    yield
+
+
+def test_signup_login_and_access():
+    with TestClient(app) as client:
+
+        resp = client.post(
+            "/signup", json={"username": "alice", "password": "pw", "role": "sre"}
+        )
+        assert resp.status_code == 200
+        api_key = resp.json()["api_key"]
+
+        resp = client.post("/login", json={"username": "alice", "password": "pw"})
+        assert resp.status_code == 200
+        assert resp.json()["api_key"] == api_key
+
+        resp = client.get("/protected", headers={"X-API-KEY": api_key})
+        assert resp.status_code == 200
+        assert resp.json() == {"protected": True}
+
+
+def test_invalid_role_forbidden():
+    with TestClient(app) as client:
+
+        resp = client.post(
+            "/signup", json={"username": "bob", "password": "pw", "role": "developer"}
+        )
+        api_key = resp.json()["api_key"]
+
+        resp = client.get("/protected", headers={"X-API-KEY": api_key})
+        assert resp.status_code == 403
+
+
+def test_missing_api_key_unauthorized():
+    with TestClient(app) as client:
+
+        client.post("/signup", json={"username": "c", "password": "pw", "role": "sre"})
+        resp = client.get("/protected")
+        assert resp.status_code == 401

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,3 +1,9 @@
+# ruff: noqa: E402
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from app.db import get_connection_string
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,12 @@
+# ruff: noqa: E402
+import sys
+from pathlib import Path
+
+# Ensure repo root in path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from fastapi.testclient import TestClient
+
 from app.main import app
 
 client = TestClient(app)


### PR DESCRIPTION
## Summary
- store users in MongoDB with Beanie
- rework signup/login/logout routes to use Mongo
- initialize MongoDB on startup
- containerize app with Mongo service
- update tests to use mongomock and ensure path setup

## Testing
- `pre-commit run --files tests/test_auth.py tests/test_db.py tests/test_main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687a1ae92f848326a57347f7c33c56d6